### PR TITLE
Update common_api_handler.js

### DIFF
--- a/routes/middlewares/common_api_handler.js
+++ b/routes/middlewares/common_api_handler.js
@@ -399,6 +399,7 @@ class CommonAPIHandler{
 			case "image/jpeg":
 			case "image/gif":
 			case "image/tiff":
+			case "image/tif":
 			case "image/svg+xml":
 			case "image/bmp":
 			case "image/webp":


### PR DESCRIPTION
added missing encodeType _"image/tif"_ that was causing the SDKException:
```
node:internal/process/promises:246
          triggerUncaughtException(err, true /* fromPromise */);
          ^

SDKException [Error]: TypeError: Cannot read properties of null (reading 'getWrappedResponse')
    at CommonAPIHandler.apiCall (C:\workspace\projects\zoho-attachments-download-script\node_modules\zcrmsdk\routes\middlewares\common_api_handler.js:317:13)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```

**Context:**
While downloading attachments from Zoho CRM with a nodejs cron job this error occurred several times, so I debugged it and found that while downloading images with ".tif" extension the received media type was slighty different, thus the function `getConverterClassInstance` was returning a null value. Adding the missing media type fixed the error.